### PR TITLE
Add overload methods for convenience

### DIFF
--- a/src/main/groovy/org/gradle/guides/test/fixtures/FunctionalTestingSupport.groovy
+++ b/src/main/groovy/org/gradle/guides/test/fixtures/FunctionalTestingSupport.groovy
@@ -44,8 +44,24 @@ trait FunctionalTestingSupport implements FunctionalTestFixture {
      * {@inheritDoc}
      */
     @Override
+    BuildResult succeeds(List<String> arguments) {
+        delegate.succeeds(arguments)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     BuildResult succeeds(String... arguments) {
         delegate.succeeds(arguments)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    BuildResult fails(List<String> arguments) {
+        delegate.fails(arguments)
     }
 
     /**

--- a/src/main/java/org/gradle/guides/test/fixtures/DefaultFunctionalTestFixture.java
+++ b/src/main/java/org/gradle/guides/test/fixtures/DefaultFunctionalTestFixture.java
@@ -6,6 +6,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class DefaultFunctionalTestFixture implements FunctionalTestFixture {
 
@@ -46,7 +48,7 @@ public class DefaultFunctionalTestFixture implements FunctionalTestFixture {
      * {@inheritDoc}
      */
     @Override
-    public BuildResult succeeds(String... arguments) {
+    public BuildResult succeeds(List<String> arguments) {
         return withArguments(arguments).build();
     }
 
@@ -54,11 +56,27 @@ public class DefaultFunctionalTestFixture implements FunctionalTestFixture {
      * {@inheritDoc}
      */
     @Override
-    public BuildResult fails(String... arguments) {
+    public BuildResult succeeds(String... arguments) {
+        return succeeds(Arrays.asList(arguments));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BuildResult fails(List<String> arguments) {
         return withArguments(arguments).buildAndFail();
     }
 
-    private GradleRunner withArguments(String... arguments) {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BuildResult fails(String... arguments) {
+        return fails(Arrays.asList(arguments));
+    }
+
+    private GradleRunner withArguments(List<String> arguments) {
         gradleRunner.withArguments(arguments);
         return gradleRunner;
     }

--- a/src/main/java/org/gradle/guides/test/fixtures/FunctionalTestFixture.java
+++ b/src/main/java/org/gradle/guides/test/fixtures/FunctionalTestFixture.java
@@ -4,6 +4,7 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 
 import java.io.File;
+import java.util.List;
 
 public interface FunctionalTestFixture {
 
@@ -29,6 +30,16 @@ public interface FunctionalTestFixture {
      *
      * @param arguments Arguments
      * @return Build result
+     * @see #succeeds(String...)
+     */
+    BuildResult succeeds(List<String> arguments);
+
+    /**
+     * Executes build for provided arguments and expects it finish successfully.
+     *
+     * @param arguments Arguments
+     * @return Build result
+     * @see #succeeds(List)
      */
     BuildResult succeeds(String... arguments);
 
@@ -37,6 +48,16 @@ public interface FunctionalTestFixture {
      *
      * @param arguments Arguments
      * @return Build result
+     * @see #fails(String...)
+     */
+    BuildResult fails(List<String> arguments);
+
+    /**
+     * Executes build for provided arguments and expects it fail.
+     *
+     * @param arguments Arguments
+     * @return Build result
+     * @see #fails(List)
      */
     BuildResult fails(String... arguments);
 

--- a/src/test/groovy/org/gradle/guides/test/fixtures/DefaultFunctionalTestFixtureTest.groovy
+++ b/src/test/groovy/org/gradle/guides/test/fixtures/DefaultFunctionalTestFixtureTest.groovy
@@ -147,6 +147,13 @@ class DefaultFunctionalTestFixtureTest extends Specification {
         then:
         result.task(':helloWorld').outcome == FAILED
         result.output.contains('expected failure')
+
+        when:
+        result = fixture.fails(['helloWorld'])
+
+        then:
+        result.task(':helloWorld').outcome == FAILED
+        result.output.contains('expected failure')
     }
 
     def "can configure GradleRunner instance"() {
@@ -157,6 +164,14 @@ class DefaultFunctionalTestFixtureTest extends Specification {
         when:
         fixture.gradleRunner.forwardStdOutput(output)
         def result = fixture.succeeds('helloWorld')
+
+        then:
+        result.task(':helloWorld').outcome == SUCCESS
+        output.toString().contains('Hello World!')
+
+        when:
+        fixture.gradleRunner.forwardStdOutput(output)
+        result = fixture.succeeds(['helloWorld'])
 
         then:
         result.task(':helloWorld').outcome == SUCCESS


### PR DESCRIPTION
Methods `succeeds` and `fails` can be called with `List<String>` type for arguments.